### PR TITLE
creating a cron-workflow to run the cronjob

### DIFF
--- a/openshift/cronworkflow.yaml
+++ b/openshift/cronworkflow.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: sync-job-cw
+spec:
+  schedule: "0 10 14 * *"
+  timezone: "Etc/UTC"
+  concurrencyPolicy: "Replace"
+  startingDeadlineSeconds: 0
+  workflowSpec:
+    entrypoint: sync-job-wt
+    templates:
+      container:
+        image: quay.io/thoth-station/sync-job:v0.2.3-dev
+        command: ["oc", "process"]
+        args: ["-p IMAGE_VERSION='v0.2.3-dev'", "-p THOTH_SYNC_FORCE='0'", "-p THOTH_SYNC_GRACEFUL='0'", "-p THOTH_SYNC_DEBUG='0'", "-f openshift.yaml", " | oc apply -f -"]


### PR DESCRIPTION
## Related Issues and Dependencies

Partially addresses: https://github.com/thoth-station/thoth-application/issues/2513

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Implementing a cronWorkflow to run the job.

## Description

I was wondering if I need to be able to use `oc login` inside of the container before it runs the script, otherwise how else would it know where to push the changes to?