### PR TITLE
Remove pre-commit deps

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,6 @@ hypothesis-auto = "*"
 hypothesis = "*"
 pytest-mypy = "*"
 mypy = "*"
-pre-commit = "==2.0.1"
 
 [packages]
 thoth-storages = "*"


### PR DESCRIPTION
pre-commit should not be part of the venv, but of the system running the
hooks (dev machine, CI container).
Runnning pre-commit inside the venv currently does not work, which seems
to support this.
